### PR TITLE
docs(examples): update `tmi` connect example to use `secure`

### DIFF
--- a/docs/code-templates/tmi.js/FDGTConnect.md
+++ b/docs/code-templates/tmi.js/FDGTConnect.md
@@ -2,6 +2,9 @@
 const tmi = require('tmi.js')
 const client = new tmi.Client({
 	connection: {
+		// The secure config is required if you're using tmi on the server.
+		// Node doesn't handle automatically upgrading .dev domains to use TLS.
+		secure: true,
 		server: 'irc.fdgt.dev',
 	},
 })


### PR DESCRIPTION
Connections to `fdgt` *must* be made over HTTPS. This is because `.dev` domains are included on the HSTS preload list (more info [here](https://scotthelme.co.uk/hsts-preloading/)). Compatible browsers can handle that regardless of whether the `secure` key is set. However, `tmi` is often used in Node environments, and Node *doesn't* use the HSTS preload list.