### PR TITLE
docs: Add twitchchat library example

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,10 +3,11 @@
   "plugins": [
     ["prismjs", {
         "languages": [
-					"csharp",
-					"java",
-					"javascript"
-				],
+          "csharp",
+          "java",
+          "javascript",
+          "rust"
+        ],
         "plugins": [],
         "theme": null,
         "css": false

--- a/docs/code-templates/twitchchat/FDGTConnect.md
+++ b/docs/code-templates/twitchchat/FDGTConnect.md
@@ -1,0 +1,14 @@
+```rust
+use twitchchat::{Connector, Dispatcher, Runner};
+use tokio::net::TcpStream;
+
+let dispatcher = Dispatcher::new();
+let(mut runner, mut control) = Runner::new(dispatcher.clone());
+
+// Uses a tokio TcpStream instead of the connect_easy wrapper
+let connector = Connector::new(|| async move {
+    TcpStream::connect("irc.fdgt.dev:6667").await
+});
+
+runner.run_to_completion(connector).await;
+```

--- a/docs/code-templates/twitchchat/NormalConnect.md
+++ b/docs/code-templates/twitchchat/NormalConnect.md
@@ -1,0 +1,18 @@
+```rust
+use twitchchat::{
+    Connector, 
+    Dispatcher, 
+    Runner, 
+    native_tls
+};
+
+let dispatcher = Dispatcher::new();
+let(mut runner, mut control) = Runner::new(dispatcher.clone());
+
+// nick and pass are your twitch credentials in quotes
+let connector = Connector::new(|| async move {
+    twitchchat::native_tls::connect_easy(nick, pass).await
+});
+
+runner.run_to_completion(connector).await;
+```

--- a/docs/code-templates/twitchchat/PRIVMSG.md
+++ b/docs/code-templates/twitchchat/PRIVMSG.md
@@ -1,0 +1,3 @@
+```rust
+control.writer().privmsg("#channel", "{{message}}").await?;
+```


### PR DESCRIPTION
Documentation for Rust's twitchchat IRC library with fdgt

Note: Not tested locally since I couldn't build the website